### PR TITLE
Fixes the `siriproxy` commandline utility 'update' command

### DIFF
--- a/lib/siriproxy/command_line.rb
+++ b/lib/siriproxy/command_line.rb
@@ -12,7 +12,7 @@ class SiriProxy::CommandLine
   BANNER = <<-EOS
 Siri Proxy is a proxy server for Apple's Siri "assistant." The idea is to allow for the creation of custom handlers for different actions. This can allow developers to easily add functionality to Siri.
 
-See: http://github.com/plamoni/SiriProxy/
+See: http://github.com/westbaer/SiriProxy/
 
 Usage: siriproxy COMMAND OPTIONS
 
@@ -116,12 +116,12 @@ Options:
     else
       branch_opt = @branch ? "-b #{@branch}" : ""
       @branch = "master" if @branch == nil
-      puts "=== Installing latest code from git://github.com/plamoni/SiriProxy.git [#{@branch}] ==="
+      puts "=== Installing latest code from git://github.com/westbaer/SiriProxy.git [#{@branch}] ==="
 
 	  tmp_dir = "/tmp/SiriProxy.install." + (rand 9999).to_s.rjust(4, "0")
 
 	  `mkdir -p #{tmp_dir}`
-      puts `git clone #{branch_opt} git://github.com/plamoni/SiriProxy.git #{tmp_dir}`  if $?.exitstatus == 0
+      puts `git clone #{branch_opt} git://github.com/westbaer/SiriProxy.git #{tmp_dir}`  if $?.exitstatus == 0
       puts "=== Performing Rake Install ===" if $?.exitstatus == 0
       puts `cd #{tmp_dir} && rake install`  if $?.exitstatus == 0
       puts "=== Bundling ===" if $?.exitstatus == 0


### PR DESCRIPTION
It now fetches from the correct fork. I spent a very long
time figuring out why my SiriProxy wasn't working because
of this :P
