### PR TITLE
Added iPad 3 data caching

### DIFF
--- a/lib/siriproxy/connection.rb
+++ b/lib/siriproxy/connection.rb
@@ -79,6 +79,9 @@ class SiriProxy::Connection < EventMachine::Connection
       if line.match(/iPhone4,1/)
         puts "[Warning] 4S device connected. Keys will be saved."
         @faux = false
+      elsif line.match(/iPad3,1;/)
+	puts "[Warning] iPad 3 device connected. Keys will be saved."
+        @faux = false
       else
         puts "[Warning] Non-4S device connected."
         @faux = true

--- a/lib/siriproxy/connection.rb
+++ b/lib/siriproxy/connection.rb
@@ -80,7 +80,13 @@ class SiriProxy::Connection < EventMachine::Connection
         puts "[Warning] 4S device connected. Keys will be saved."
         @faux = false
       elsif line.match(/iPad3,1;/)
-	puts "[Warning] iPad 3 device connected. Keys will be saved."
+	puts "[Warning] iPad 3 WiFi device connected. Keys will be saved."
+        @faux = false
+      elsif line.match(/iPad3,2;/)
+	puts "[Warning] iPad 3 CDMA device connected. Keys will be saved."
+        @faux = false
+      elsif line.match(/iPad3,3;/)
+	puts "[Warning] iPad 3 GSM device connected. Keys will be saved."
         @faux = false
       else
         puts "[Warning] Non-4S device connected."


### PR DESCRIPTION
My fork caches validation data from iPad 3's. Unfortunately, however, the data from an iPad 3 is only good for dictation and not Siri.
